### PR TITLE
Bluetooth proxy passive and active

### DIFF
--- a/packages/bluetooth_proxy.yaml
+++ b/packages/bluetooth_proxy.yaml
@@ -7,4 +7,7 @@ esp32:
     type: esp-idf
 
 esp32_ble_tracker:
+  scan_parameters:
+    active: false
 bluetooth_proxy:
+  active: false


### PR DESCRIPTION
If no active parameter is not specified the proxy will be active by default from 2025.9
Updated the templates to reflect the canges